### PR TITLE
Enhance feature types mapping

### DIFF
--- a/src/ml_performance_monitoring/monitor.py
+++ b/src/ml_performance_monitoring/monitor.py
@@ -200,9 +200,11 @@ class MLPerformanceMonitoring:
     def _calc_columns_types(self, df):
         columns_types = (
             df.dtypes.apply(str)
-            .replace(
-                {r"^(float|int).*": "numeric", "object": "categorical"}, regex=True
-            )
+            .replace({
+                r"^.*(float|int|complex).*": "numeric",
+                r"^(object|bool|category).*": "categorical",
+                r"^(date).*": "datetime"
+            }, regex=True)
             .rename("types")
         )
         return columns_types


### PR DESCRIPTION
Provides `feature_type` remapping:

- Possible `feature_type` for pandas: `numeric`, `categorical`, `datetime`
  - float, int, uint are mapped to `numeric`
  - bool, category and object are mapped to `categorical`
  - datetime is mapped to `datetime`
  - other data types will be mapped to their own type alias (kept as is)

- for numpy: `numeric`, `categorical`
  - all numeric types are mapped to `numeric`
  - all other types should be mapped to `categorical`

Notice: the `feature_type` attribute defines how UI components show up
