### PR TITLE
Added inference metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,6 @@ poetry.lock
 
 # vscode
 .vscode
+
+#pyenv
+.python-version

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     - id: nbqa-isort
       args: ["--nbqa-mutate"]
 - repo: https://github.com/timothycrosley/isort
-  rev: 5.8.0
+  rev: 5.12.0
   hooks:
     - id: isort
       args: ["--profile", "black"]
@@ -22,7 +22,7 @@ repos:
   hooks:
     - id: mypy
       args: [--ignore-missing-imports, --pretty, --show-error-codes]
-- repo: https://gitlab.com/pycqa/flake8
+- repo: https://github.com/PyCQA/flake8
   rev:  3.9.2
   hooks:
     - id: flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
     - id: flake8
       args: ["--ignore=E501,W503,E203,E231"]
 - repo: https://github.com/asottile/pyupgrade
-  rev: v2.19.4
+  rev: v3.3.1
   hooks:
   -   id: pyupgrade
 -   repo: https://github.com/pre-commit/pygrep-hooks
@@ -38,7 +38,7 @@ repos:
       - id: python-no-eval
       - id: python-no-log-warn
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.0.1
+  rev: v4.4.0
   hooks:
     - id: check-case-conflict
     - id: check-merge-conflict

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "ml-performance-monitoring provides a Python library for sending m
 authors = ["AIR <applied-intelligence-research-team@newrelic.com>"]
 
 [tool.poetry.dependencies]
-python = ">=3.7,<3.11"
+python = ">=3.8,<3.11"
 newrelic-telemetry-sdk = "^0.4.2"
 numpy = '*'
 
@@ -13,6 +13,9 @@ numpy = '*'
 pytest = "^6.2.1"
 tox = "^3.20.1"
 tox-pyenv = "^1.1.0"
+
+[tool.poetry.group.dev.dependencies]
+pandas = "^1.5.3"
 
 [tool.nbqa.addopts]
 isort = ["--profile=black"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ml-performance-monitoring"
-version = "0.1.6"
+version = "0.1.7"
 description = "ml-performance-monitoring provides a Python library for sending model data & metrics to New Relic, directly from a Jupyter notebook or any other platform. This library is based of the “newrelic_telemetry_sdk” library."
 authors = ["AIR <applied-intelligence-research-team@newrelic.com>"]
 

--- a/src/ml_performance_monitoring/monitor.py
+++ b/src/ml_performance_monitoring/monitor.py
@@ -9,14 +9,8 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import pandas as pd
-from newrelic_telemetry_sdk import (
-    EventBatch,
-    EventClient,
-    GaugeMetric,
-    Harvester,
-    MetricBatch,
-    MetricClient,
-)
+from newrelic_telemetry_sdk import (EventBatch, EventClient, GaugeMetric,
+                                    Harvester, MetricBatch, MetricClient)
 from newrelic_telemetry_sdk.event import Event
 
 logger = logging.getLogger("ml_performance_monitoring")
@@ -121,7 +115,7 @@ class MLPerformanceMonitoring:
         if (
             not isinstance(self.insert_key, str) and self.insert_key is not None
         ) or self.insert_key is None:
-            raise TypeError("insert_key instance type must str and not None")
+            raise TypeError("insert_key instance type must be str and not None")
         self._start()
 
     def _log(self, msg: str):
@@ -249,6 +243,7 @@ class MLPerformanceMonitoring:
         flat: pd.DataFrame,
         y: pd.DataFrame,
         metadata: Dict[str, Any],
+        inference_id_to_inference_metadata: Dict[str, Dict[str, str]],
         timestamp: Optional[int] = None,
         params: Optional[Dict[str, Any]] = None,
     ) -> Sequence[Event]:
@@ -256,12 +251,17 @@ class MLPerformanceMonitoring:
 
         request_id = self.get_request_id()
         for t in flat.itertuples(index=False, name=None):
+            curr_inference_metadata = (
+                inference_id_to_inference_metadata[t[0]]
+                if inference_id_to_inference_metadata is not None
+                else {}
+            )
             events.append(
                 self.tuple_to_event(
                     t,
                     flat.columns.to_list(),
                     request_id,
-                    metadata,
+                    metadata | curr_inference_metadata,
                     timestamp,
                 )
             )
@@ -285,10 +285,21 @@ class MLPerformanceMonitoring:
         X: Union[pd.DataFrame, np.ndarray],
         y: Union[pd.DataFrame, np.ndarray],
         *,
+        inference_metadata: List[Dict[str, str]] = {},
         data_summary_min_rows: int = 100,
         timestamp: Optional[int] = None,
     ):
-        """This method send inference data to the table "InferenceData" in New Relic NRDB"""
+        """Send inference data to the New Relic Database.
+        Tha data could be viewed on the "Model performence" page and in the table "InferenceData" in New Relic NRDB
+
+
+        Args:
+            X (Union[pd.DataFrame, np.ndarray]): A list of features
+            y (Union[pd.DataFrame, np.ndarray]): A list of the resulting labels
+            inference_metadata (List[Dict[str, str]], optional): Additional data about the each inference, the
+                data will be added to each inference in the NRDB. Each Item in the list is a Dict of key-value items, describing
+                A single inference. Defaults to None.
+        """
         self.static_metadata.update(
             {
                 "modelName": self.model_name,
@@ -301,6 +312,10 @@ class MLPerformanceMonitoring:
             raise TypeError("y instance type must be pd.DataFrame or np.ndarray")
         if len(X) != len(y):
             raise ValueError("X and y must have the same length")
+        elif len(inference_metadata) > 0 and len(inference_metadata) != len(X):
+            raise ValueError(
+                "inference_metadata must have the same length as X and y or have a length of 0"
+            )
         if not isinstance(X, pd.DataFrame):
             X = pd.DataFrame(
                 list(map(np.ravel, X)),
@@ -319,6 +334,9 @@ class MLPerformanceMonitoring:
         infid_to_uuid = {
             infid: str(uuid.uuid4()) for infid in X_df["inference_id"].unique()
         }
+        inference_id_to_inference_metadata = dict(
+            zip(infid_to_uuid.values(), inference_metadata)
+        )
         X_df["inference_id"] = X_df["inference_id"].apply(lambda x: infid_to_uuid[x])
         X_df["batch.index"] = X_df.groupby("inference_id").cumcount()
 
@@ -367,6 +385,7 @@ class MLPerformanceMonitoring:
             X_df,
             y_df,
             metadata=self.static_metadata,
+            inference_id_to_inference_metadata=inference_id_to_inference_metadata,
             timestamp=timestamp,
         )
         try:
@@ -400,7 +419,9 @@ class MLPerformanceMonitoring:
         metrics_batch: List[GaugeMetric] = []
         for metric, value in metrics.items():
             if not isinstance(value, (int, float)):
-                self._log(f"Sending failed for metric {metric}: value instance type must be int or float and not {type(value)}")
+                self._log(
+                    f"Sending failed for metric {metric}: value instance type must be int or float and not {type(value)}"
+                )
                 continue
             metrics_batch.append(
                 GaugeMetric(metric, value, metadata, end_time_ms=timestamp)

--- a/src/ml_performance_monitoring/monitor.py
+++ b/src/ml_performance_monitoring/monitor.py
@@ -9,8 +9,14 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import pandas as pd
-from newrelic_telemetry_sdk import (EventBatch, EventClient, GaugeMetric,
-                                    Harvester, MetricBatch, MetricClient)
+from newrelic_telemetry_sdk import (
+    EventBatch,
+    EventClient,
+    GaugeMetric,
+    Harvester,
+    MetricBatch,
+    MetricClient,
+)
 from newrelic_telemetry_sdk.event import Event
 
 logger = logging.getLogger("ml_performance_monitoring")
@@ -251,11 +257,7 @@ class MLPerformanceMonitoring:
 
         request_id = self.get_request_id()
         for t in flat.itertuples(index=False, name=None):
-            curr_inference_metadata = (
-                inference_id_to_inference_metadata[t[0]]
-                if inference_id_to_inference_metadata is not None
-                else {}
-            )
+            curr_inference_metadata = inference_id_to_inference_metadata[t[0]] or {}
             events.append(
                 self.tuple_to_event(
                     t,
@@ -285,7 +287,7 @@ class MLPerformanceMonitoring:
         X: Union[pd.DataFrame, np.ndarray],
         y: Union[pd.DataFrame, np.ndarray],
         *,
-        inference_metadata: List[Dict[str, str]] = {},
+        inference_metadata: List[Dict[str, str]] = [],
         data_summary_min_rows: int = 100,
         timestamp: Optional[int] = None,
     ):

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,3 +1,4 @@
+import os
 import uuid
 from unittest import mock
 
@@ -15,9 +16,21 @@ monitor = MLPerformanceMonitoring(
     metadata=metadata,
     label_type="categorical",
 )
+monitor._record_events = mock.Mock()
+
+
+def setup_function(function):
+    monitor._record_events.reset_mock()
+
+
+def teardown_function(function):
+    pass
 
 
 def test_init_insert_key():
+    if os.environ.get("NEW_RELIC_INSERT_KEY") is not None:
+        del os.environ["NEW_RELIC_INSERT_KEY"]
+
     with pytest.raises(Exception) as insert_key_type:
         MLPerformanceMonitoring(
             insert_key=123456789,
@@ -28,7 +41,7 @@ def test_init_insert_key():
         )
     assert (
         insert_key_type.value.args[0]
-        == "insert_key instance type must str and not None"
+        == "insert_key instance type must be str and not None"
     )
 
     with pytest.raises(Exception) as insert_key_missing:
@@ -40,7 +53,7 @@ def test_init_insert_key():
         )
     assert (
         insert_key_missing.value.args[0]
-        == "insert_key instance type must str and not None"
+        == "insert_key instance type must be str and not None"
     )
 
 
@@ -92,10 +105,9 @@ def test_init_model_version():
             metadata=metadata,
             label_type="categorical",
         )
-    assert (
-        model_version_missing.value.args[0]
-        == ('MLPerformanceMonitoring.__init__() missing 1 required positional argument: '
- "'model_version'")
+    assert model_version_missing.value.args[0] == (
+        "MLPerformanceMonitoring.__init__() missing 1 required positional argument: "
+        "'model_version'"
     )
 
     with pytest.raises(Exception) as model_version_type:
@@ -155,28 +167,25 @@ def test_init_output_type():
 def test_record_inference_data_x_y_missing():
     with pytest.raises(Exception) as missing_X_y:
         monitor.record_inference_data()
-    assert (
-        missing_X_y.value.args[0]
-        == ('MLPerformanceMonitoring.record_inference_data() missing 2 required '
- "positional arguments: 'X' and 'y'")
+    assert missing_X_y.value.args[0] == (
+        "MLPerformanceMonitoring.record_inference_data() missing 2 required "
+        "positional arguments: 'X' and 'y'"
     )
 
     with pytest.raises(Exception) as missing_y:
         monitor.record_inference_data(
             X=np.array([[11, 12, 5, 2], [15, 1, 6, 10], [10, 8, 12, 5], [12, 15, 8, 6]])
         )
-    assert (
-        missing_y.value.args[0]
-        == ('MLPerformanceMonitoring.record_inference_data() missing 1 required '
- "positional argument: 'y'")
+    assert missing_y.value.args[0] == (
+        "MLPerformanceMonitoring.record_inference_data() missing 1 required "
+        "positional argument: 'y'"
     )
 
     with pytest.raises(Exception) as missing_X:
         monitor.record_inference_data(y=[11, 12, 5, 2, 4])
-    assert (
-        missing_X.value.args[0]
-        == ('MLPerformanceMonitoring.record_inference_data() missing 1 required '
- "positional argument: 'X'")
+    assert missing_X.value.args[0] == (
+        "MLPerformanceMonitoring.record_inference_data() missing 1 required "
+        "positional argument: 'X'"
     )
 
 
@@ -206,11 +215,63 @@ def test_record_inference_data_x_y_same_length():
     assert X_y_length.value.args[0] == "X and y must have the same length"
 
 
-def test_record_inference_data():
-    monitor.record_inference_data(
-        X=np.array([[11, 12, 5, 2], [1, 15, 6, 10], [10, 8, 12, 5], [12, 15, 8, 6]]),
-        y=np.array([11, 12, 5, 2]),
+def test_record_inference_data_x_y_inference_metadata_same_length():
+    with pytest.raises(Exception) as X_y_metadata_length:
+        monitor.record_inference_data(
+            X=np.array(
+                [[11, 12, 5, 2], [1, 15, 6, 10], [10, 8, 12, 5], [12, 15, 8, 6]]
+            ),
+            y=np.array([11, 12, 5, 2]),
+            inference_metadata=[{"index": 1}, {"index": 2}, {"index": 3}],
+        )
+    assert (
+        X_y_metadata_length.value.args[0]
+        == "inference_metadata must have the same length as X and y or have a length of 0"
     )
+
+
+def test_record_inference_data():
+
+    record_events = monitor._record_events
+
+    monitor._record_events = mock.Mock()
+
+    monitor.record_inference_data(
+        X=np.array(
+            [
+                [11, 12, 5, 2],
+                [1, 15, 6, 10],
+                ["third", "third", "third", "third"],
+                [12, 15, 8, 6],
+            ]
+        ),
+        y=np.array([11, 12, 5, 2]),
+        inference_metadata=[
+            {"index": 1},
+            {"index": 2},
+            {"index": 3, "test": "result"},
+            {"index": 4},
+        ],
+    )
+
+    events = monitor._record_events.call_args[0][0]
+
+    # makes sure that inference metadata is assigned properly
+    assert (
+        len(
+            [
+                event
+                for event in events
+                if "test" in event
+                and event["test"] == "result"
+                and event["feature_value"] == "third"
+            ]
+        )
+        == 4
+    )
+    assert len(events) == 20
+
+    monitor._record_events = record_events
 
 
 def is_valid_uuid(val):
@@ -243,6 +304,7 @@ def test_uuid_as_inference_id():
     )
     assert len(x_df["inference_id"].unique()) == 4
 
+
 def test_metric_value(capsys):
     prep_events_mock = mock.Mock()
     monitor.prepare_events = prep_events_mock
@@ -252,6 +314,7 @@ def test_metric_value(capsys):
     }
     monitor.record_metrics(metrics=metrics)
     captured = capsys.readouterr()
-    assert captured.out == ('Sending failed for metric Recall: value instance type must be int or float '
- "and not <class 'str'>\n")
-
+    assert captured.out == (
+        "Sending failed for metric Recall: value instance type must be int or float "
+        "and not <class 'str'>\n"
+    )


### PR DESCRIPTION
https://issues.newrelic.com/browse/NR-48803

- Added an option to add metadata per inference.
 The new param is a list of dictionaries, of which, the key-value pairs are added as columns to each feature row in the NRDB.
 This solution
 
- Fixed a typo in one of the error messages
- Added docstring to one of the functions
- In the testing file, remove the `NEW_RELIC_INSERT_KEY` env var, in order to be able to run the tests locally
- formatted the files with black